### PR TITLE
Fix change that broke compilation

### DIFF
--- a/cxl_scripts/Makefile
+++ b/cxl_scripts/Makefile
@@ -11,4 +11,8 @@ vm:
 
 # Run as "make format FMT_PATHS="../path/to/format/1 ../path/to/format/2"."
 format:
+ifeq ($(FMT_PATHS), )
+	@echo No file to format, run \"make format FMT_PATHS=\"../path/to/format/1 ../path/to/format/2\".\"
+else
 	clang-format -i $(FMT_PATHS) --style=file:clang-format
+endif

--- a/hw/pci-bridge/cxl_endian.c
+++ b/hw/pci-bridge/cxl_endian.c
@@ -13,6 +13,7 @@
 
 #include "hw/cxl/cxl_endian.h"
 
+#ifndef ntohll
 uint64_t ntohll(uint64_t netllong)
 {
     return ((netllong & 0xFF) << 56) | ((netllong & 0xFF00) << 40) |
@@ -22,8 +23,11 @@ uint64_t ntohll(uint64_t netllong)
            ((netllong & 0xFF000000000000) >> 40) |
            ((netllong & 0xFF00000000000000) >> 56);
 }
+#endif
 
+#ifndef htonll
 uint64_t htonll(uint64_t hllong)
 {
     return ntohll(hllong);
 }
+#endif

--- a/include/hw/cxl/cxl_emulator_packet.h
+++ b/include/hw/cxl/cxl_emulator_packet.h
@@ -9,6 +9,7 @@
 #define CXL_EMULATOR_PACKET_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "exec/hwaddr.h"
 
@@ -405,7 +406,7 @@ typedef struct {
     rsp_performance_t rsp_pre : 2;
     uint16_t cq_id            : 12;
     uint8_t cache_id          : 4;
-    bool rsvd                 : 5;
+    uint8_t rsvd              : 5;
 } __attribute__((packed)) cxl_cache_rsp_h2d_header_t;
 
 typedef struct {

--- a/include/hw/cxl/cxl_endian.h
+++ b/include/hw/cxl/cxl_endian.h
@@ -24,14 +24,18 @@
  * (little-endian). Note that this function is not standardized by the
  * UNIX standard, but we need it anyway.
  */
+#ifndef ntohll
 uint64_t ntohll(uint64_t netllong);
+#endif
 
 /**
  * @brief Converts "host" uint64_t (little-endian) to "network" uint64_t
  * (big-endian). Note that this function is not standardized by the
  * UNIX standard, but we need it anyway.
  */
+#ifndef htonll
 uint64_t htonll(uint64_t hllong);
+#endif
 
 #define CXL_ENDIAN_H
 #endif


### PR DESCRIPTION
Fix compile error on Unix systems where ntohll/htonll are defined (Darwin)

Bit field widths were off and <stdbool.h> was not included.