### PR TITLE
Dynamic Payload Size Support

### DIFF
--- a/hw/pci-bridge/cxl_root_port.c
+++ b/hw/pci-bridge/cxl_root_port.c
@@ -239,7 +239,7 @@ void cxl_remote_mem_read(PCIDevice *d, uint64_t addr, uint64_t *val, int size)
         assert(0);
     }
 
-    uint64_t packet_size =
+    size_t packet_size =
         wait_for_cxl_io_completion_data(crp->socket_fd, tag, val);
     if (packet_size == 0) {
         release_packet_entry(tag);
@@ -308,12 +308,6 @@ void cxl_remote_config_space_read(PCIDevice *d, uint16_t bdf, uint32_t offset,
     }
 
     wait_for_cxl_io_cfg_completion(crp->socket_fd, tag, val);
-
-    /*
-    Since now the OpenCXL backend assumes 4-byte aligned data reqs,
-    We are going to make sure that we can read the data correctly
-    from correct locations. Similar to CxlIoCfgWrPacket.get_value().
-    */
 
     uint32_t lsb_diff = offset % 4;
     uint32_t msb_diff = 4 - lsb_diff;

--- a/hw/pci-bridge/cxl_root_port.c
+++ b/hw/pci-bridge/cxl_root_port.c
@@ -239,15 +239,14 @@ void cxl_remote_mem_read(PCIDevice *d, uint64_t addr, uint64_t *val, int size)
         assert(0);
     }
 
-    cxl_io_completion_data_packet_t *cxl_packet =
-        wait_for_cxl_io_completion_data(crp->socket_fd, tag);
-    if (cxl_packet == NULL) {
+    uint64_t packet_size =
+        wait_for_cxl_io_completion_data(crp->socket_fd, tag, val);
+    if (packet_size == 0) {
         release_packet_entry(tag);
         trace_cxl_root_debug_message("Failed to get CXL.io CPLD response");
         assert(0);
     }
 
-    *val = cxl_packet->data;
     release_packet_entry(tag);
 }
 
@@ -310,6 +309,18 @@ void cxl_remote_config_space_read(PCIDevice *d, uint16_t bdf, uint32_t offset,
 
     wait_for_cxl_io_cfg_completion(crp->socket_fd, tag, val);
 
+    /*
+    Since now the OpenCXL backend assumes 4-byte aligned data reqs,
+    We are going to make sure that we can read the data correctly
+    from correct locations. Similar to CxlIoCfgWrPacket.get_value().
+    */
+
+    uint32_t lsb_diff = offset % 4;
+    uint32_t msb_diff = 4 - lsb_diff;
+
+    *val <<= (msb_diff - size) * 8;
+    *val >>= ((lsb_diff + msb_diff - size)) * 8;
+
     release_packet_entry(tag);
 }
 
@@ -327,6 +338,10 @@ void cxl_remote_config_space_write(PCIDevice *d, uint16_t bdf, uint32_t offset,
     const uint8_t bus = bdf >> 8;
     const uint8_t device = bdf & 0x1F >> 3;
     const uint8_t function = bdf & 0x7;
+
+    uint32_t lsb_diff = offset % 4;
+
+    val <<= lsb_diff * 8;
 
     if (type0) {
         trace_cxl_root_cxl_io_config_space_write0(bus, device, function, offset,

--- a/hw/pci-bridge/cxl_socket_transport.c
+++ b/hw/pci-bridge/cxl_socket_transport.c
@@ -368,7 +368,7 @@ bool send_cxl_io_mem_write(int socket_fd, hwaddr hpa, uint64_t val, int size,
         assert(val < UINT32_MAX);
         base = (cxl_io_mem_base_packet_t *)&packet_32;
         payload_length = sizeof(packet_32);
-        packet_32.data = (uint32_t)(val & 0xFFFFFFFF);
+        packet_32.data = (uint32_t)(val & UINT32_MAX);
     } else {
         successful = false;
         assert(size == 4 || size == 8);

--- a/hw/pci-bridge/cxl_socket_transport.c
+++ b/hw/pci-bridge/cxl_socket_transport.c
@@ -360,7 +360,6 @@ bool send_cxl_io_mem_write(int socket_fd, hwaddr hpa, uint64_t val, int size,
     size_t payload_length = 0;
 
     if (size == 8) {
-        assert(val < UINT64_MAX);
         base = (cxl_io_mem_base_packet_t *)&packet_64;
         payload_length = sizeof(packet_64);
         packet_64.data = val;

--- a/include/hw/cxl/cxl_emulator_packet.h
+++ b/include/hw/cxl/cxl_emulator_packet.h
@@ -118,8 +118,15 @@ typedef struct {
     system_header_packet_t system_header;
     cxl_io_header_t cxl_io_header;
     cxl_io_mreq_header_t mreq_header;
-    uint64_t data; /* TODO: Support dynamic data size */
-} __attribute__((packed)) cxl_io_mem_wr_packet_t;
+    uint32_t data;
+} __attribute__((packed)) cxl_io_mem_wr_packet_32b_t;
+
+typedef struct {
+    system_header_packet_t system_header;
+    cxl_io_header_t cxl_io_header;
+    cxl_io_mreq_header_t mreq_header;
+    uint64_t data;
+} __attribute__((packed)) cxl_io_mem_wr_packet_64b_t;
 
 typedef struct {
     uint16_t req_id;
@@ -168,8 +175,15 @@ typedef struct {
     system_header_packet_t system_header;
     cxl_io_header_t cxl_io_header;
     cxl_io_completion_header_t cpl_header;
-    uint64_t data; /* TODO: Support dynamic data size */
-} __attribute__((packed)) cxl_io_completion_data_packet_t;
+    uint32_t data;
+} __attribute__((packed)) cxl_io_completion_data_packet_32b_t;
+
+typedef struct {
+    system_header_packet_t system_header;
+    cxl_io_header_t cxl_io_header;
+    cxl_io_completion_header_t cpl_header;
+    uint64_t data;
+} __attribute__((packed)) cxl_io_completion_data_packet_64b_t;
 
 /*
  * CXL.mem
@@ -365,8 +379,8 @@ typedef struct {
     cache_req_h2d_opcode_t opcode : 3;
     uint64_t addr                 : 46;
     uint16_t uq_id                : 12;
-    uint8_t cache_id              : 4;
-    uint8_t rsvd                  : 6;
+    uint16_t cache_id             : 4;
+    uint16_t rsvd                 : 6;
 } __attribute__((packed)) cxl_cache_req_h2d_header_t; /* also "a2f upstream" */
 
 typedef struct {
@@ -374,19 +388,19 @@ typedef struct {
     cache_req_d2h_opcode_t opcode : 5;
     uint16_t cq_id                : 12;
     cache_nontemporal_t nt        : 1;
-    uint8_t cache_id              : 4;
+    uint16_t cache_id             : 4;
     uint64_t addr                 : 46;
-    uint8_t rsvd                  : 7;
-}
-__attribute__((packed)) cxl_cache_req_d2h_header_t; /* also "a2f downstream" */
+    uint16_t rsvd                 : 7;
+} __attribute__((packed))
+cxl_cache_req_d2h_header_t; /* also "a2f downstream" */
 
 typedef struct {
-    bool valid       : 1;
-    uint16_t cq_id   : 12;
-    bool poison      : 1;
-    bool go_err      : 1;
-    uint8_t cache_id : 4;
-    uint16_t rsvd    : 9;
+    bool valid        : 1;
+    uint16_t cq_id    : 12;
+    bool poison       : 1;
+    bool go_err       : 1;
+    uint16_t cache_id : 4;
+    uint16_t rsvd     : 9;
 } __attribute__((packed)) cxl_cache_data_h2d_header_t; /* also "a2f upstream" */
 
 typedef struct {
@@ -395,25 +409,25 @@ typedef struct {
     bool bogus     : 1;
     bool poison    : 1;
     bool bep       : 1;
-    uint8_t rsvd   : 8;
-}
-__attribute__((packed)) cxl_cache_data_d2h_header_t; /* also "a2f downstream" */
+    uint16_t rsvd  : 8;
+} __attribute__((packed))
+cxl_cache_data_d2h_header_t; /* also "a2f downstream" */
 
 typedef struct {
     bool valid                : 1;
-    uint8_t opcode            : 4;
+    uint16_t opcode           : 4;
     cache_state_t rsp_data    : 12;
     rsp_performance_t rsp_pre : 2;
     uint16_t cq_id            : 12;
-    uint8_t cache_id          : 4;
-    uint8_t rsvd              : 5;
+    uint16_t cache_id         : 4;
+    uint16_t rsvd             : 5;
 } __attribute__((packed)) cxl_cache_rsp_h2d_header_t;
 
 typedef struct {
     bool valid                 : 1;
     cxl_cache_rsp_d2h_t opcode : 5;
     uint16_t uq_id             : 12;
-    uint8_t rsvd               : 6;
+    uint16_t rsvd              : 6;
 } __attribute__((packed)) cxl_cache_rsp_d2h_header_t;
 
 /* PACKET DEFINITIONS */

--- a/include/hw/cxl/cxl_emulator_packet.h
+++ b/include/hw/cxl/cxl_emulator_packet.h
@@ -112,19 +112,15 @@ typedef struct {
     system_header_packet_t system_header;
     cxl_io_header_t cxl_io_header;
     cxl_io_mreq_header_t mreq_header;
-} __attribute__((packed)) cxl_io_mem_rd_packet_t;
+} __attribute__((packed)) cxl_io_mem_base_packet_t;
 
 typedef struct {
-    system_header_packet_t system_header;
-    cxl_io_header_t cxl_io_header;
-    cxl_io_mreq_header_t mreq_header;
+    cxl_io_mem_base_packet_t headers;
     uint32_t data;
 } __attribute__((packed)) cxl_io_mem_wr_packet_32b_t;
 
 typedef struct {
-    system_header_packet_t system_header;
-    cxl_io_header_t cxl_io_header;
-    cxl_io_mreq_header_t mreq_header;
+    cxl_io_mem_base_packet_t headers;
     uint64_t data;
 } __attribute__((packed)) cxl_io_mem_wr_packet_64b_t;
 

--- a/include/hw/cxl/cxl_socket_transport.h
+++ b/include/hw/cxl/cxl_socket_transport.h
@@ -42,8 +42,8 @@ bool send_cxl_io_config_space_write(int socket_fd, uint16_t bdf,
                                     bool type0, uint16_t *tag);
 cxl_io_completion_packet_t *wait_for_cxl_io_completion(int socket_fd,
                                                        uint16_t tag);
-cxl_io_completion_data_packet_t *wait_for_cxl_io_completion_data(int socket_fd,
-                                                                 uint16_t tag);
+uint64_t wait_for_cxl_io_completion_data(int socket_fd, uint16_t tag,
+                                         uint64_t *data);
 void wait_for_cxl_io_cfg_completion(int socket_fd, uint16_t tag,
                                     uint32_t *data);
 

--- a/include/hw/cxl/cxl_socket_transport.h
+++ b/include/hw/cxl/cxl_socket_transport.h
@@ -42,8 +42,8 @@ bool send_cxl_io_config_space_write(int socket_fd, uint16_t bdf,
                                     bool type0, uint16_t *tag);
 cxl_io_completion_packet_t *wait_for_cxl_io_completion(int socket_fd,
                                                        uint16_t tag);
-uint64_t wait_for_cxl_io_completion_data(int socket_fd, uint16_t tag,
-                                         uint64_t *data);
+size_t wait_for_cxl_io_completion_data(int socket_fd, uint16_t tag,
+                                       uint64_t *data);
 void wait_for_cxl_io_cfg_completion(int socket_fd, uint16_t tag,
                                     uint32_t *data);
 


### PR DESCRIPTION
This commit brings support to dynamic payload size corresponding to the change in the Core side (see https://github.com/opencxl/opencxl-core/pull/29). 

This commit also brings support to config space read/write handling on the Core side (see https://github.com/opencxl/opencxl-core/pull/37). 

QEMU will fail to boot up without this commit when using OpenCXL core with those two core-side commits.

Signed-off-by: Xiangqun Zhang <xzhang84@syr.edu>